### PR TITLE
Improve reading into BROWSERS array

### DIFF
--- a/common/profile-sync-daemon.in
+++ b/common/profile-sync-daemon.in
@@ -114,12 +114,7 @@ fi
 
 # scope to sync defined in BROWSERS array or from list of supported browsers
 if [[ -z "$BROWSERS" ]]; then
-  read -r -d '' TMP_SCRIPT <<EOF
-    find "$SHAREDIR/browsers" -type f -printf "%f\n";
-    find "$PSDCONFDIR/browsers" -type f -printf "%f\n"
-EOF
-
-  mapfile -t BROWSERS < <(bash -c "$TMP_SCRIPT" | sort | uniq)
+  mapfile -t BROWSERS < <(find "$SHAREDIR/browsers" "$PSDCONFDIR/browsers" -type f -printf "%f\n" 2> /dev/null)
 else
   if ! declare -p BROWSERS | grep -q 'declare \-a'; then
     # did not setup as array so redefine it here


### PR DESCRIPTION
 1. find can receive multiple starting points
 2. If one of the directories doesn't exist there's an error

So simply add the second dirctory, and send the stderr to /dev/null.